### PR TITLE
add response and error handlers to MarkupHandler options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@britecore/ui-plugins-client",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "main": "src/index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,11 @@ class AutoCompleteHandler extends PluginHandler {
 class MarkupHandler extends PluginHandler {
   
   getModel() {
-    return this.options.methods || {}
+    return {
+      ...this.options.methods,
+      handleResponse,
+      handleError
+    } || {}
   }
 
   getOptions() {
@@ -200,6 +204,8 @@ class MarkupHandler extends PluginHandler {
       ...this.options,
       template: `<div>${this.options.template || defaultOptions.template}</div>`,
       methods: Object.keys(this.getModel()),
+      handleResponse: 'handleResponse', // from 'handleResponse' function in PluginHandler,
+      handleError: 'handleError' // from 'handleError' function in PluginHandler
     };
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -180,7 +180,7 @@ describe('MarkupHandler', () => {
   test('`getOptions` should return default options if not passed', () => {
     const handler = new MarkupHandler({})
     expect(handler.getOptions()).toHaveProperty('template', '<div></div>')
-    expect(handler.getOptions()).toHaveProperty('methods', [])
+    expect(handler.getOptions()).toHaveProperty('methods', ['handleResponse', 'handleError'])
     expect(handler.getOptions()).toHaveProperty('data', {})
   });
 
@@ -192,7 +192,7 @@ describe('MarkupHandler', () => {
 
   test('`getOptions` replaces methods with their own names', () => {
     const handler = new MarkupHandler(options)
-    expect(handler.getOptions().methods).toEqual(['handleClick'])
+    expect(handler.getOptions().methods).toEqual(['handleClick', 'handleResponse', 'handleError'])
   });
 
   test('`getModel` returns the options methods', () => {


### PR DESCRIPTION
### Problem
We currently do not support this methods which are user in our vendor plugin architecture.

### Solution
By adding this we are able to turn our current `button-row` plugins into `markup` plugins when needed with minimal changes.


### Testing

##### Automatic
![image](https://user-images.githubusercontent.com/27866894/104407475-6d014600-5540-11eb-9379-b010f5d7670e.png)

##### Manual
No manual QA needed for this one.

### Dependent PR
None

### User Story
[US21600](https://rally1.rallydev.com/#/398457870712d/teamboard?detail=%2Fuserstory%2F435825382768&fdp=true?fdp=true): Replace Credit Score Prompt