### PR TITLE
fix: autocomplete requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@britecore/ui-plugins-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ class ButtonRowHandler extends PluginHandler {
 
 class AutoCompleteHandler extends PluginHandler {
   getModel() {
-    let callbacks = []
+    let callbacks = [handleResponse, handleError]
     for (const input of this.options.inputs) {
       callbacks.push(input.querySearch, input.handleSelect)
     }


### PR DESCRIPTION
## Problem

https://rally1.rallydev.com/#/398457870712d/teamboard?detail=%2Fuserstory%2F423679372516&fdp=true?fdp=true

There is an issue with autocomplete slots that prevents them from handling the response of BriteCorePluginRequest because the plugin doesn't expose the handleReponse, and handleError methods.


## Solution

Exposed the handleReponse, and handleError methods.