### PR TITLE
chore: run build before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
         node-version: '12.x'
     - name: Publish to NPM
       run: |
+        npm install
+        npm run build
         npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
         npm publish --ignore-scripts --access public
       env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@britecore/ui-plugins-client",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "src/index.js",
+  "module": "src/index.js",
+  "unpkg": "dist/britecore-ui-plugins.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "serve": "webpack-dev-server",
@@ -9,6 +11,10 @@
     "coverage": "jest --collect-coverage",
     "prepublish": "npm run build"
   },
+  "files": [
+    "dist/*",
+    "src/*"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "penpal": "^5.2.1",


### PR DESCRIPTION
## Problem

The dist directory is not getting published, hence it can't be accessed through unpkg cdn.

## Solution

Run the build command pre-publishing.
Add `unpkg` attribute so it can be used by [unpkg](https://unpkg.com/) as an entry point.