### PR TITLE
feature: add support for context change handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@britecore/ui-plugins-client",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "main": "src/index.js",
   "module": "src/index.js",
   "unpkg": "dist/britecore-ui-plugins.js",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "webpack --config webpack.config.js",
     "serve": "webpack-dev-server",
     "test": "jest",
+    "lint": "eslint src",
     "coverage": "jest --collect-coverage",
     "prepublish": "npm run build"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,19 @@ import WaitNotify from 'wait-notify';
  * PluginHandler that will be used to read the plugin settings and expose the
  * interface that the plugin has to expose with the plugin slot.
  */
-class PluginHandler {
+export class PluginHandler {
 
   /**
    * Build a handler to deal with a given type of Plugin Slot.
    * @param options an Object with the plugin configuration (varies on a plugin basis).
    */
   constructor(options) {
-    this.options = options
+    // extract onContextUpdate if it is passed in the options
+    const {onContextUpdate, ...modifiedOptions} = options
+    if (onContextUpdate && typeof onContextUpdate === "function") {
+      this.onContextUpdate = onContextUpdate
+    }
+    this.options = modifiedOptions
   }
 
   /**
@@ -46,6 +51,9 @@ class PluginHandler {
   handleContextUpdate(context, parent) {
     this.lastContext = context
     this.parent = parent
+    if (this.onContextUpdate && typeof this.onContextUpdate === "function") {
+      this.onContextUpdate(context, parent)
+    }
   }
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
-import { connectToParent } from 'penpal';
-import { AutoCompleteHandler, BriteCorePlugin, ButtonRowHandler, MarkupHandler, PluginHandler } from './index';
+import { connectToParent } from 'penpal'
+import { AutoCompleteHandler, BriteCorePlugin, ButtonRowHandler, MarkupHandler, PluginHandler } from './index'
 
 jest.mock("penpal")
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
-import { BriteCorePlugin, ButtonRowHandler, AutoCompleteHandler, MarkupHandler } from './index'
-import { connectToParent } from 'penpal'
+import { connectToParent } from 'penpal';
+import { AutoCompleteHandler, BriteCorePlugin, ButtonRowHandler, MarkupHandler, PluginHandler } from './index';
 
 jest.mock("penpal")
 
@@ -36,7 +36,7 @@ describe('BriteCorePlugin', () => {
     expect(connectToParent).toHaveBeenCalledTimes(1)
   });
 
-  it('should should have button-row handler', () => {
+  it('should have button-row handler', () => {
     expect(p).toHaveProperty("handlers")
     expect(p.handlers).toHaveProperty("button-row")
   });
@@ -63,6 +63,23 @@ describe('BriteCorePlugin', () => {
 });
 
 
+describe('PluginHandler', () => {
+
+
+  it('should accept `onContextUpdate` function as an option and call it whenever the context changes', () => {
+    let onContextUpdateMock = jest.fn()
+    const options = {
+      onContextUpdate: onContextUpdateMock
+    }
+    let pluginHandler = new PluginHandler(options)
+    pluginHandler.handleContextUpdate({}, fakeParent)
+    expect(onContextUpdateMock).toHaveBeenCalled()
+    onContextUpdateMock.mockReset()
+    pluginHandler = new PluginHandler({})
+    pluginHandler.handleContextUpdate({}, fakeParent)
+    expect(onContextUpdateMock).toBeCalledTimes(0)
+  })
+})
 
 describe('ButtonRowHandler', () => {
   const buttonCallback1 = () => {}


### PR DESCRIPTION
## Problem

We need a way to watch for context changes on the plugin side so we can react to those changes.


## Solution

Added a new option for the handlers named `onContextUpdate` which should be a function that will get called whenever a change happens to the context.

for example:

```javascript
export const plugin = new BriteCorePlugin('some plugin')

function handleContextUpdate(context, parent) {
  console.log(context, parent)
}

plugin.initialize({
  'button-row': {
    onContextUpdate: handleContextUpdate
  },
})

```
every time the context is updated on the parent it will call the `handleContextUpdate`.


## User story

[US24718](https://rally1.rallydev.com/#/398457870712d/teamboard?detail=%2Fuserstory%2F491978716708&fdp=true?fdp=true): Delos | ISO prefill & 360Value | Automate running plugin

